### PR TITLE
Improve README and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,26 @@ Install the required dependencies before using `YParser`:
 
 ```bash
 pip install -r requirements.txt
+
+# optional: install pandas if you want DataFrame output
+pip install pandas
+```
+
+## Usage
+
+```python
+from yparser.parser import YParser
+
+parser = YParser(
+    name="imgs",
+    save_folder="imgs",
+    download_workers=2,
+    parser_workers=1,
+    limits=[10, 20],
+    wandb_log=False,
+)
+
+parser.parse([
+    "https://i.ytimg.com/vi/bj4QiFmFy2M/maxresdefault.jpg",
+])
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 selenium>=3.141.0
 webdriver-manager>=3.3.0
 wandb>=0.10.30
+numpy
+Pillow


### PR DESCRIPTION
## Summary
- add missing numpy and Pillow dependencies
- update README with installation and usage instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .` *(fails: line too long errors etc.)*
- `python -m unittest discover` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_684cba72ec24832d9fc3295c9fc35a93