### PR TITLE
Fix webdriver initialization and add text query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,30 @@ parser.parse([
     "https://i.ytimg.com/vi/bj4QiFmFy2M/maxresdefault.jpg",
 ])
 ```
+
+### Text query example
+
+To parse search results for several phrases use the `parse_type='text'` mode:
+
+```python
+from yparser.parser import YParser
+
+queries = [
+    "Christine Todd Whitman",
+    "Steve Lavin",
+    "Doris Roberts",
+    "Bridget Fonda",
+    "Richard Virenque",
+]
+
+parser = YParser(
+    name="people",
+    save_folder="imgs",
+    download_workers=2,
+    parser_workers=1,
+    limits=[10],
+    parse_type="text",
+)
+
+parser.parse(queries)
+```

--- a/yparser/src/parser/utils.py
+++ b/yparser/src/parser/utils.py
@@ -1,5 +1,6 @@
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
 
 from yparser.src.parser.js_code import JS_DROP_FILE
 from yparser.src.consts import IN_COLAB
@@ -18,9 +19,10 @@ def init_wd(headless=True):
         chrome_options.add_argument('--disable-dev-shm-usage')
     if IN_COLAB:
         download_incolab_chromedriver()
-        wd = webdriver.Chrome('chromedriver', options=chrome_options)
+        service = Service('chromedriver')
     else:
-        wd = webdriver.Chrome(executable_path=ChromeDriverManager().install(), options=chrome_options)
+        service = Service(ChromeDriverManager().install())
+    wd = webdriver.Chrome(service=service, options=chrome_options)
     return wd
 
 


### PR DESCRIPTION
## Summary
- fix Selenium webdriver initialization compatible with Selenium 4
- document parsing text queries via YParser with an example

## Testing
- `flake8 yparser/src/parser/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cbf60810c832db89708d9dac25eb1