### PR TITLE
Fix README install docs and add text query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pip install -r requirements.txt
 
 # optional: install pandas if you want DataFrame output
 pip install pandas
+pip install -e .
 ```
 
 ## Usage

--- a/examples/colab_text_example.py
+++ b/examples/colab_text_example.py
@@ -1,0 +1,26 @@
+"""Google Colab example for text queries using yparser.
+This script shows how to parse image URLs for several phrases on Colab.
+"""
+
+from yparser.parser import YParser
+
+queries = [
+    "Christine Todd Whitman",
+    "Steve Lavin",
+    "Doris Roberts",
+    "Bridget Fonda",
+    "Richard Virenque",
+]
+
+SAVE_PATH = "imgs"
+
+parser = YParser(
+    name="people",
+    save_folder=SAVE_PATH,
+    download_workers=2,
+    parser_workers=1,
+    limits=[10],
+    parse_type="text",
+)
+
+parser.parse(queries)


### PR DESCRIPTION
## Summary
- add `pip install -e .` step to README
- provide a minimal Colab example for text queries

## Testing
- `flake8 examples/colab_text_example.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc82ffabc832d8633c3814002cfc8